### PR TITLE
Display.published_to_js

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,6 +11,13 @@ Modules = [AbstractPlutoDingetjes.Bonds]
 Order   = [:function, :type]
 ```
 
+# Display
+
+```@autodocs
+Modules = [AbstractPlutoDingetjes.Display]
+Order   = [:function]
+```
+
 # Extras
 
 ```@autodocs

--- a/src/AbstractPlutoDingetjes.jl
+++ b/src/AbstractPlutoDingetjes.jl
@@ -248,6 +248,18 @@ end
 module Display
 import ..AbstractPlutoDingetjes
 
+
+struct _PublishToJS
+    x
+end
+function Base.show(io::IO, ::MIME"text/javascript", ptj::_PublishToJS)
+    core_publish_to_js = get(io, :pluto_publish_to_js, nothing)
+    @assert core_publish_to_js !== nothing
+
+    core_publish_to_js(io, ptj.x)
+end
+publish_to_js(x) = _PublishToJS(x)
+
 end
 
 end

--- a/src/AbstractPlutoDingetjes.jl
+++ b/src/AbstractPlutoDingetjes.jl
@@ -258,6 +258,8 @@ function Base.show(io::IO, ::MIME"text/javascript", ptj::_PublishToJS)
 
     core_published_to_js(io, ptj.x)
 end
+Base.show(io::IO, ::MIME"text/plain", ptj::_PublishToJS) = show(io, MIME"text/javascript"(), ptj)
+Base.show(io::IO, ptj::_PublishToJS) = show(io, MIME"text/javascript"(), ptj)
 
 """
 ```julia

--- a/src/AbstractPlutoDingetjes.jl
+++ b/src/AbstractPlutoDingetjes.jl
@@ -253,12 +253,12 @@ struct _PublishToJS
     x
 end
 function Base.show(io::IO, ::MIME"text/javascript", ptj::_PublishToJS)
-    core_publish_to_js = get(io, :pluto_publish_to_js, nothing)
-    @assert core_publish_to_js !== nothing
+    core_published_to_js = get(io, :pluto_published_to_js, nothing)
+    @assert core_published_to_js !== nothing
 
-    core_publish_to_js(io, ptj.x)
+    core_published_to_js(io, ptj.x)
 end
-publish_to_js(x) = _PublishToJS(x)
+published_to_js(x) = _PublishToJS(x)
 
 end
 

--- a/src/AbstractPlutoDingetjes.jl
+++ b/src/AbstractPlutoDingetjes.jl
@@ -246,6 +246,7 @@ end
 
 module Display
 import ..AbstractPlutoDingetjes
+export published_to_js
 
 
 struct _PublishToJS

--- a/src/AbstractPlutoDingetjes.jl
+++ b/src/AbstractPlutoDingetjes.jl
@@ -274,7 +274,7 @@ Base.show(io::IO, ptj::_PublishToJS) = show(io, MIME"text/javascript"(), ptj)
 AbstractPlutoDingetjes.Display.published_to_js(x)
 ```
 
-Make the object `x` available to the JS runtime of this cell, to be rendered inside a `<script>` element.
+Make the object `x` available to the JS runtime of this cell, to be rendered inside a `<script>` element. This system uses Pluto's optimized data transfer, which is much more efficient for large amounts of data, including lossless transfer for `Vector{UInt8}` and `Vector{Float64}` (see the table below).
 
 # Example
 ```julia
@@ -297,6 +297,31 @@ let
     "\"")
 end
 ```
+
+# Types
+
+| Julia | JavaScript |
+|:---------- |:---------- |
+| `String`, `Symbol` | `string` |
+| `Boolean` | `boolean` |
+| `Int64`, `Int32`, `Int16`, `Int8`, `UInt64`, `UInt32`, `UInt16`, `UInt8`, `Float32`, `Float64` | `Number` |
+| `Nothing`, `Missing` | `null` |
+| `DateTime` | [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) |
+| `UUID`, `MIME` | `string` |
+| --- | --- |
+| `Dict` | `object` |
+| `NamedTuple` | `object` |
+| `Vector` | `Array` |
+| `Tuple` | `Array` |
+| `Vector{Int8}` | [`Int8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array) |
+| `Vector{UInt8}` | [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) |
+| `Vector{Int16}` | [`Int16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array) |
+| `Vector{UInt16}` | [`Uint16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array) |
+| `Vector{Int32}` | [`Int32Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array) |
+| `Vector{UInt32}` | [`Uint32Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array) |
+| `Vector{Float32}` | [`Float32Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array) |
+| `Vector{Float64}` | [`Float64Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array) |
+
 
 # Note about IO context
 

--- a/src/AbstractPlutoDingetjes.jl
+++ b/src/AbstractPlutoDingetjes.jl
@@ -258,6 +258,36 @@ function Base.show(io::IO, ::MIME"text/javascript", ptj::_PublishToJS)
 
     core_published_to_js(io, ptj.x)
 end
+
+"""
+```julia
+AbstractPlutoDingetjes.Display.published_to_js(x)
+```
+
+Make the object `x` available to the JS runtime of this cell, to be interpolated inside a `<script>` element.
+
+# Example
+```julia
+import HypertextLiteral: @htl
+import AbstractPlutoDingetjes.Display: published_to_js
+
+let
+    x = Dict(
+        "data" => rand(Float64, 20),
+        "name" => "juliette",
+    )
+
+    @htl("\""
+    <script>
+    // we interpolate into JavaScript:
+    const x = \$(published_to_js(x))
+
+    console.log(x.name, x.data)
+    </script>
+    "\"")
+end
+```
+"""
 published_to_js(x) = _PublishToJS(x)
 
 end


### PR DESCRIPTION
To expose https://github.com/fonsp/Pluto.jl/pull/1124

I changed the name from `publish_to_js` to `published_to_js` to make it clear that this is declarative: calling the function on its own has no effect, data is only published when interpolating this into a script.

TODO:
- [x] docs
- [x] document how msgpack transforms types
- [ ] document caching
- [x] matching Pluto PR https://github.com/fonsp/Pluto.jl/pull/2162
- [x] better error message when not rendered inside Pluto
- [ ] allow specifying a fallback? can be added later upon request?
- [ ] maybe add tricks to support older versions of Pluto?